### PR TITLE
image_types_ota.bbclass: fix do_image_otaimg failure

### DIFF
--- a/classes/image_types_ota.bbclass
+++ b/classes/image_types_ota.bbclass
@@ -146,7 +146,7 @@ IMAGE_CMD:otaimg () {
 			rm -rf ${WORKDIR}/rootfs_ota_uboot
 			mkdir -p ${WORKDIR}/rootfs_ota_uboot
 
-			bootdir=$(grep ^bootdir= ${PHYS_SYSROOT}/boot/loader/uEnv.txt)
+			bootdir=$(grep ^bootdir= ${PHYS_SYSROOT}/boot/loader/uEnv.txt || echo "")
 			bootdir=${bootdir#bootdir=}
 			if [ "$bootdir" != "" ] && [ -e "${PHYS_SYSROOT}/boot$bootdir" ] ; then
 				cp -r ${PHYS_SYSROOT}/boot$bootdir/*  ${WORKDIR}/rootfs_ota_uboot


### PR DESCRIPTION
when "grep ^bootdir" failed, the failure will be catched
by trap (trap 'bb_sh_exit_handler' 0) during exectuing following
line and do_image_otaimg will fail.
bootdir=$(grep ^bootdir= ${PHYS_SYSROOT}/boot/loader/uEnv.txt)

Signed-off-by: Changqing Li <changqing.li@windriver.com>