### PR TITLE
mttyexec: fix do_compile error

### DIFF
--- a/recipes-support/mttyexec/files/mttyexec-0.1/mttyexec.c
+++ b/recipes-support/mttyexec/files/mttyexec-0.1/mttyexec.c
@@ -277,7 +277,7 @@ int main(int argc, char **argv)
 				printf("Error not enough arguments\n");
 				cleanup(1);
 			}
-			fd_file = open(argv[i], O_RDWR|O_APPEND|O_CREAT);
+			fd_file = open(argv[i], O_APPEND|O_CREAT, O_RDWR);
 			if (fd_file < 0) {
 				printf("Error failed to open file: %s\n", argv[i]);
 				cleanup(1);


### PR DESCRIPTION
fix error:
inlined from 'main' at mttyexec.c:280:14:
| mttyexec/0.1-r0/recipe-sysroot/usr/include/bits/fcntl2.h:50:11: error: call to '__open_missing_mode' declared with attribute error: open with O_CREAT or O_TMPFILE in second argument needs 3 arguments