### PR TITLE
meta-lat: remove setting WRL_RECIPES from templates

### DIFF
--- a/templates/feature/ostree/template.conf
+++ b/templates/feature/ostree/template.conf
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2016-2019 Wind River Systems, Inc.
+# Copyright (C) 2016-2019,2022 Wind River Systems, Inc.
 #
 
 BANNER[feature_ostree-sample-keys] = "${@'WARNING: You are using the example Wind River gpg signing keys.  These keys are provided as samples and are unsafe to use in production.  Please consider running "layers/meta-secure-core/meta-signing-key/scripts/create-user-key-store.sh".  This script can generate a complete set of new keys and print the variables you should set in the local.conf.' if d.getVar('OSTREE_GPGDIR') == (d.getVar('WR_SAMPLE_KEYS_DIR') + "/rpm_keys") else ''}"
@@ -15,10 +15,6 @@ CONFIG_BANNER[feature_ostree] = "${@bb.utils.contains('BBFILE_COLLECTIONS', 'lat
 
 DISTRO_FEATURES:append = " ostree usrmerge"
 IMAGE_CLASSES += "flux-ota"
-
-WRL_RECIPES:lat-layer += 'initramfs-ostree initramfs-ostree-image ostree-upgrade-mgr u-boot-uenv mttyexec'
-
-WRL_RECIPES:openembedded-layer += 'pv ostree'
 
 WKS_FILE = "${OSTREE_WKS_FILE}"
 


### PR DESCRIPTION
Templates are only availabl to people using Wind River Linux and in an attempt to simplify their content the use of WRL_RECIPES is being dropped from most templates. Here we are dropping the use of WRL_RECIPES from the ostree template.

Signed-off-by: Mark Asselstine <mark.asselstine@windriver.com>