### PR TITLE
watchdog_ostree.inc: select the correct clearbootflag.sh

### DIFF
--- a/classes/image_types_ostree.bbclass
+++ b/classes/image_types_ostree.bbclass
@@ -127,7 +127,7 @@ create_tarball_and_ostreecommit() {
 			--tree=dir=${OSTREE_ROOTFS} \
 			--skip-if-unchanged \
 			--branch=${_image_basename} \
-			--timestamp=${_timestamp} \
+			--timestamp="${_timestamp}" \
 			--subject="Commit-id: ${_image_basename}-${MACHINE}-${DATETIME}"
 		# Pull new commmit into old repo
 		flock ${OSTREE_REPO}.lock ostree --repo=${OSTREE_REPO} pull-local ${OSTREE_REPO_TEMP} ${_image_basename}
@@ -167,7 +167,7 @@ create_tarball_and_ostreecommit() {
 				--gpg-sign="${OSTREE_GPGID}" \
 				--gpg-homedir=$gpg_path \
 				--branch=${_image_basename} \
-				--timestamp=${_timestamp} \
+				--timestamp="${_timestamp}" \
 				--subject="Commit-id: ${_image_basename}-${MACHINE}-${DATETIME}"
 		else
 			PATH="${WORKDIR}:$PATH" ostree --repo=${OSTREE_REPO_TEMP} commit \
@@ -176,7 +176,7 @@ create_tarball_and_ostreecommit() {
 				--gpg-sign="${OSTREE_GPGID}" \
 				--gpg-homedir=$gpg_path \
 				--branch=${_image_basename} \
-				--timestamp=${_timestamp} \
+				--timestamp="${_timestamp}" \
 				--subject="Commit-id: ${_image_basename}-${MACHINE}-${DATETIME}"
 		fi
 		# Pull new commmit into old repo

--- a/recipes-support/watchdog/watchdog_ostree.inc
+++ b/recipes-support/watchdog/watchdog_ostree.inc
@@ -1,5 +1,5 @@
 def get_arch_setting_watchdog(bb, d):
-    if d.getVar('TRANSLATED_TARGET_ARCH') in [ 'x86-64', 'i686' ]:
+    if d.getVar('TRANSLATED_TARGET_ARCH') in [ 'x86-64', 'i686', 'i586' ]:
         return "x86_64"
     else:
         return "arm"


### PR DESCRIPTION
Some machine, eg:amd-snowyowl-64, the TRANSLATED_TARGET_ARCH is set as 'i586', in this case, the clearbootflag_arm.sh will be used. This commit fixes this so that clearbootflag_x86_64.sh is used.

Signed-off-by: Changqing Li <changqing.li@windriver.com>