### PR TITLE
Install efibootmgr in rootfs on x86 and x86-64 for feature/ostree

### DIFF
--- a/templates/feature/ostree/image.inc
+++ b/templates/feature/ostree/image.inc
@@ -1,0 +1,1 @@
+IMAGE_INSTALL:append:x86-64 = " efibootmgr"

--- a/templates/feature/ostree/image.inc
+++ b/templates/feature/ostree/image.inc
@@ -1,1 +1,2 @@
+IMAGE_INSTALL:append:x86 = " efibootmgr"
 IMAGE_INSTALL:append:x86-64 = " efibootmgr"


### PR DESCRIPTION
The efi boot menu will be modified by init-ostree-install.sh, so install
efibootmgr in rootfs to make user can modify it back.