### PR TITLE
meta-lat: fix error about importing GPG key

### DIFF
--- a/classes/image_types_ostree.bbclass
+++ b/classes/image_types_ostree.bbclass
@@ -19,6 +19,8 @@ do_image_ostree[depends] = "ostree-native:do_populate_sysroot \
 
 do_prepare_recipe_sysroot[depends] += "${OSTREE_GPG_DEP}"
 
+PSEUDO_IGNORE_PATHS .= ",${GPG_PATH}"
+
 #export REPRODUCIBLE_TIMESTAMP_ROOTFS ??= "`date --date="20${WRLINUX_YEAR_VERSION}-01-01 +${WRLINUX_WW_VERSION}weeks" +%s`"
 export BUILD_REPRODUCIBLE_BINARIES = "1"
 


### PR DESCRIPTION
Fix the error:
ERROR: initramfs-ostree-image-1.0-r0 do_rootfs:
 Could not import GPG key for ostree signing:
gpg: key CFA856DFC7CB87BE: public key "Wind-River-Linux-Sample (RPM Signing Certificate) <svc-linux@gmail.com>" imported gpg: key CFA856DFC7CB87BE/CFA856DFC7CB87BE: error sending to agent: End of file gpg: error reading '....../layers/wrlinux/wrlinux-distro/files/sample-keys/rpm_keys/RPM-GPG-PRIVKEY-Wind-River-Linux-Sample': End of file gpg: import from '....../layers/wrlinux/wrlinux-distro/files/sample-keys/rpm_keys/RPM-GPG-PRIVKEY-Wind-River-Linux-Sample' failed: End of file

This is caused by PSEUDO issue, and can be solved by set GPG_PATH into PSEUDO_IGNORE_PATHS and config a proper path for GPG_PATH in local.conf.