### PR TITLE
genimage: make bzImage link unvarying

### DIFF
--- a/recipes-support/genimage/files/genimage/genimage.py
+++ b/recipes-support/genimage/files/genimage/genimage.py
@@ -922,7 +922,7 @@ class GenExtDebImage(GenImage):
         utils.run_cmd_oneshot("cp -r -f %s/* %s" % (rootfs_efi, self.deploydir))
 
         # Create symlink bzIamge to kernel
-        for kernel in glob.glob(os.path.join(self.deploydir, 'vmlinuz-*-amd64')):
+        for kernel in glob.glob(os.path.join(self.deploydir, 'vmlinuz-*[0-9]-amd64')):
             utils.run_cmd_oneshot("ln -snf -r %s bzImage" % kernel, cwd=self.deploydir)
             if self.data['gpg']['grub'].get('EFI_SECURE_BOOT', 'disable') == 'enable':
                 utils.run_cmd_oneshot("ln -snf -r %s.sig bzImage.sig" % kernel, cwd=self.deploydir)


### PR DESCRIPTION
The bzImage link won't affect multi kernel support. But its changing can cause RR patch apply failed with below error after initial INSVC patch apply and removal:
OSTree:ERROR:src/libostree/ostree-sysroot-deploy.c:1630: install_deployment_kernel: assertion failed
(kernel_layout->bootcsum == bootcsum)

Make bzImage link unvarying.