### PR TITLE
startup-container: Start up container without attach

### DIFF
--- a/recipes-support/startup-container/files/start-container@.service
+++ b/recipes-support/startup-container/files/start-container@.service
@@ -1,12 +1,15 @@
 [Unit]
 Description=Run docker container %I
-Requires=docker.service
-After=docker.service
+Wants=docker.service podman.service
+After=docker.service podman.service
 
 [Service]
 Type=forking
+ExecStartPre=/bin/bash -c 'mkdir -p /tmp/start-container; while [ $(ls /tmp/start-container | wc -l) -ge 3 ]; do sleep 1; done; touch /tmp/start-container/%i'
 ExecStart=/usr/bin/docker start %i
-ExecStop=/usr/bin/docker stop -t 5 %i
+ExecStartPost=rm /tmp/start-container/%i
+ExecStop=/bin/bash -c 'mkdir -p /tmp/start-container; while [ $(ls /tmp/start-container | wc -l) -ge 3 ]; do sleep 1; done; touch /tmp/start-container/%i; /usr/bin/docker stop -t 5 %i'
+ExecStopPost=rm /tmp/start-container/%i
 
 [Install]
 WantedBy=multi-user.target

--- a/recipes-support/startup-container/files/start-container@.service
+++ b/recipes-support/startup-container/files/start-container@.service
@@ -4,7 +4,8 @@ Requires=docker.service
 After=docker.service
 
 [Service]
-ExecStart=/usr/bin/docker start -a %i
+Type=forking
+ExecStart=/usr/bin/docker start %i
 ExecStop=/usr/bin/docker stop -t 5 %i
 
 [Install]


### PR DESCRIPTION
With attach option, the docker process will consume about 40M memory, when multilib containers is started, it will consume too much memeory, even make OOM happened when memory is not big enough, to save memory, remove attach option.

Set Type to forking to make the child continues to run as the main service process after the parent process "docker start" exit.