### PR TITLE
genimage: fix the order of the kernel files in making bootcheckum

### DIFF
--- a/recipes-support/genimage/files/genimage/genimage.py
+++ b/recipes-support/genimage/files/genimage/genimage.py
@@ -862,7 +862,6 @@ class GenExtDebImage(GenImage):
         if self.data.get('multiple-kernels'):
             for ks in self.data.get('multiple-kernels').split():
                 kernels.extend(glob.glob(ks, root_dir=os.path.join(rootfs.target_rootfs, "boot/")))
-            kernels = set(kernels)
             os.environ['OSTREE_MULTIPLE_KERNELS'] = ' '.join(kernels) if kernels else ''
         logger.debug("kernels %s", kernels)
 


### PR DESCRIPTION
Ostree bootchecksum is calculated from four files, they are standard kernel image, rt kernel image, vmlinuz and initramfs file. Different order makes different checksum value.

WRCP's INSVC patch does not touch kernel images or initramfs file while it requires a fixed bootchecksum value. So fix the order as standard kernel, rt kernel, vmlinuz and initramfs.

Here "kernels" is a list contains standard kernel and then rt kernel. Remove line "kernels = set(kernels)" to avoid the randomization of their order.